### PR TITLE
fix/deploy-vercel-path-error

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+    "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
+}


### PR DESCRIPTION
1.有些套件，使用官方推薦的自動import後，運行時候會自動生成auto-imports.d.ts 跟 components.d.ts 導致執行完後，確認後要提交時候，會有git衝突
2.當時在dev環境下，自動生成了auto-imports.d.ts 跟 components.d.ts配置，只好在dev環境下將2隻檔案移動到 .gitignore，並做commit提交
3.因為部屬到 vercel ，此時 Vercel 在部署時無法使用這個自動生成的類型聲明文件，會導致部屬error
4.在env.d.ts 做了配置 ( 上一個分支 )
5.此分支添加 vercel.json 調整路徑切換問題