### PR TITLE
update/member-page-editmember

### DIFF
--- a/src/views/member-page/EditMemberPage.vue
+++ b/src/views/member-page/EditMemberPage.vue
@@ -2,9 +2,12 @@
 import { computed, onMounted, ref, watch } from 'vue'
 import { taiwanCity } from '@/content/city' //引入城市鄉鎮
 import { useMemberStore } from '@/stores/member'
+import type { FormInstance } from 'element-plus'
 const memberStore = useMemberStore()
 const isLoading = ref<Boolean>(false)
 const isWatchAreas = ref<Boolean>(false)
+const isEditInfo = ref<Boolean>(false)
+const isEditPassWord = ref<Boolean>(false)
 const memberInput = ref({
   ...memberStore.getMemberInfo
 })
@@ -40,17 +43,24 @@ const handleCitySelect = () => {
 const handleAreaSelect = () => {
   isWatchAreas.value = false
 }
-//點擊儲存 發送修改
-const handleMemberInfo = async () => {
-  isLoading.value = true
-  try {
-    const response = await memberStore.updateMemberInfo(memberInput.value)
-    message(response.message, 'success')
-  } catch (error: any) {
-    message(error.message, 'error')
-  } finally {
-    isLoading.value = false
-  }
+const handleMemberInfo = async (formEl: FormInstance | undefined) => {
+  if (!formEl) return
+  await formEl.validate(async (valid, fields) => {
+    if (valid) {
+      isLoading.value = true
+      try {
+        const response = await memberStore.updateMemberInfo(memberInput.value)
+        message(response.message, 'success')
+        isEditInfo.value = false
+      } catch (error: any) {
+        message(error.message, 'error')
+      } finally {
+        isLoading.value = false
+      }
+    } else {
+      // message('驗證失敗', 'error')
+    }
+  })
 }
 const message = (mes: any, mesType: any): void => {
   //@ts-ignore
@@ -69,8 +79,19 @@ watch(
   }
 )
 
+const ruleMemberInfo = ref<FormInstance>()
+const memberInfoRule = ref({
+  account: [
+    {
+      type: 'email',
+      required: true,
+      message: '信箱格式不相符',
+      trigger: ['change']
+    }
+  ]
+})
+
 //以下為更改密碼 邏輯設定
-import type { FormInstance } from 'element-plus'
 const ruleFormRef = ref<FormInstance>()
 const verifyNewPassWord = (rule: any, value: any, callback: any) => {
   if (value === '') {
@@ -83,17 +104,17 @@ const verifyNewPassWord = (rule: any, value: any, callback: any) => {
 }
 const changePasswordRules = ref({
   oldPassWord: [
-    { min: 6, max: 30, message: '長度介於6到30之間', trigger: 'blur' },
-    { required: true, message: '必填', trigger: 'blur' }
+    // { min: 6, max: 30, message: '長度介於6到30之間', trigger: 'change' },
+    { required: true, message: '必填', trigger: 'change' }
   ],
   newPassWord: [
-    { min: 6, max: 30, message: '長度介於6到30之間', trigger: 'blur' },
-    { required: true, message: '必填', trigger: 'blur' }
+    // { min: 6, max: 30, message: '長度介於6到30之間', trigger: 'change' },
+    { required: true, message: '必填', trigger: 'change' }
   ],
   checkNewPassWord: [
-    { min: 6, max: 30, message: '長度介於6到30之間', trigger: 'blur' },
-    { required: true, message: '必填', trigger: 'blur' },
-    { validator: verifyNewPassWord, trigger: 'blur' }
+    // { min: 6, max: 30, message: '長度介於6到30之間', trigger: 'change' },
+    { required: true, message: '必填', trigger: 'change' },
+    { validator: verifyNewPassWord, trigger: 'change' }
   ]
 })
 
@@ -107,6 +128,8 @@ const handleChangePassword = async (formEl: FormInstance | undefined) => {
           password: updatePassWord.value.newPassWord
         }
         const response = await memberStore.updateMemberPassword(newPassword)
+        formEl.resetFields()
+        isEditPassWord.value = false
         message(response.message, 'success')
       } catch (error: any) {
         message(error.message, 'error')
@@ -118,6 +141,18 @@ const handleChangePassword = async (formEl: FormInstance | undefined) => {
     }
   })
 }
+
+const handleEditInfo = (formEl: FormInstance | undefined) => {
+  isEditInfo.value = !isEditInfo.value
+  memberInput.value = { ...memberStore.getMemberInfo }
+  if (!formEl) return
+  formEl.clearValidate()
+}
+const handleEditPassWord = (formEl: FormInstance | undefined) => {
+  isEditPassWord.value = !isEditPassWord.value
+  if (!formEl) return
+  formEl.resetFields() //密碼不需要紀錄 ，取消直接全部重置就好
+}
 </script>
 <template>
   <h2
@@ -128,23 +163,29 @@ const handleChangePassword = async (formEl: FormInstance | undefined) => {
   <div class="rounded border">
     <h3 class="border-b p-5 text-3xl font-bold">個人資訊</h3>
     <div class="px-5 py-8">
-      <el-form :model="memberInput" :label-position="'top'" v-loading="isLoading">
+      <el-form
+        :model="memberInput"
+        :label-position="'top'"
+        v-loading="isLoading"
+        ref="ruleMemberInfo"
+        :rules="memberInfoRule"
+      >
         <div class="flex flex-col gap-x-6 md:flex-row">
           <!-- 電子郵件 -->
           <el-form-item label="全名" class="el-flex-grow">
             <!-- <el-input v-model="memberData.name" type="text" /> -->
-            <el-input v-model="memberInput.name" type="text" />
+            <el-input v-model="memberInput.name" type="text" :disabled="!isEditInfo" />
           </el-form-item>
-          <el-form-item label="電子郵件" class="el-flex-grow">
+          <el-form-item label="電子郵件" class="el-flex-grow" prop="account">
             <!-- <el-input v-model="memberData.email" type="email" /> -->
-            <el-input v-model="memberInput.account" type="email" />
+            <el-input v-model="memberInput.account" type="email" :disabled="!isEditInfo" />
           </el-form-item>
         </div>
         <!-- 手機號碼 & 出生日期-->
         <div class="flex flex-col gap-x-6 md:flex-row md:items-center md:justify-between">
           <el-form-item label="手機號碼" class="el-flex-grow">
             <!-- <el-input v-model="memberData.phone" type="phone" /> -->
-            <el-input v-model="memberInput.phoneNumber" type="phone" />
+            <el-input v-model="memberInput.phoneNumber" type="phone" :disabled="!isEditInfo" />
           </el-form-item>
           <el-form-item label="出生日期" class="el-flex-grow">
             <!-- <el-date-picker v-model="memberData.both" type="date" placeholder="選擇日期" /> -->
@@ -154,13 +195,14 @@ const handleChangePassword = async (formEl: FormInstance | undefined) => {
               placeholder="選擇日期"
               format="YYYY/MM/DD"
               value-format="YYYY-MM-DD"
+              :disabled="!isEditInfo"
             />
           </el-form-item>
         </div>
         <!-- 性別 -->
         <div>
           <el-form-item label="性別">
-            <el-radio-group v-model="memberInput.gender">
+            <el-radio-group v-model="memberInput.gender" :disabled="!isEditInfo">
               <el-radio :value="0">男性</el-radio>
               <el-radio :value="1">女性</el-radio>
               <el-radio :value="2">其他</el-radio>
@@ -173,7 +215,12 @@ const handleChangePassword = async (formEl: FormInstance | undefined) => {
         >
           <p class="w-full">地址</p>
           <div class="flex-grow">
-            <el-select v-model="memberInput.city" placeholder="城市" @change="handleCitySelect">
+            <el-select
+              v-model="memberInput.city"
+              placeholder="城市"
+              @change="handleCitySelect"
+              :disabled="!isEditInfo"
+            >
               <el-option
                 v-for="cityItem in cities"
                 :key="cityItem"
@@ -183,7 +230,12 @@ const handleChangePassword = async (formEl: FormInstance | undefined) => {
             </el-select>
           </div>
           <div class="flex-grow">
-            <el-select v-model="memberInput.area" placeholder="地區" @change="handleAreaSelect">
+            <el-select
+              v-model="memberInput.area"
+              placeholder="地區"
+              @change="handleAreaSelect"
+              :disabled="!isEditInfo"
+            >
               <el-option
                 v-for="areaItem in areas"
                 :key="areaItem"
@@ -193,13 +245,27 @@ const handleChangePassword = async (formEl: FormInstance | undefined) => {
             </el-select>
           </div>
           <div class="w-full">
-            <el-input v-model="memberInput.address" placeholder="地址" />
+            <el-input v-model="memberInput.address" placeholder="地址" :disabled="!isEditInfo" />
           </div>
         </div>
-        <div class="flex py-5">
+        <div class="flex items-center justify-end py-5" v-if="!isEditInfo">
           <button
-            class="ms-auto rounded border border-secondary-900 px-14 py-2 font-bold text-secondary-900 md:py-3"
-            @click.prevent="handleMemberInfo"
+            class="rounded border border-secondary-900 px-14 py-2 font-bold text-secondary-900 md:py-3"
+            @click.prevent="handleEditInfo(ruleMemberInfo)"
+          >
+            更改資訊
+          </button>
+        </div>
+        <div class="flex items-center justify-end gap-x-4 py-5" v-else>
+          <button
+            class="rounded border border-secondary-900 px-14 py-2 font-bold text-secondary-900 md:py-3"
+            @click.prevent="handleEditInfo(ruleMemberInfo)"
+          >
+            取消
+          </button>
+          <button
+            class="rounded border border-secondary-900 px-14 py-2 font-bold text-secondary-900 md:py-3"
+            @click.prevent="handleMemberInfo(ruleMemberInfo)"
           >
             儲存資料
           </button>
@@ -222,20 +288,46 @@ const handleChangePassword = async (formEl: FormInstance | undefined) => {
         v-loading="isLoading"
       >
         <el-form-item label="當前密碼" prop="oldPassWord">
-          <el-input v-model="updatePassWord.oldPassWord" type="password" />
+          <el-input
+            v-model="updatePassWord.oldPassWord"
+            type="password"
+            :disabled="!isEditPassWord"
+          />
         </el-form-item>
         <el-form-item label="輸入新密碼" prop="newPassWord">
-          <el-input v-model="updatePassWord.newPassWord" type="password" />
+          <el-input
+            v-model="updatePassWord.newPassWord"
+            type="password"
+            :disabled="!isEditPassWord"
+          />
         </el-form-item>
         <el-form-item label="確認新密碼" prop="checkNewPassWord">
-          <el-input v-model="updatePassWord.checkNewPassWord" type="password" />
+          <el-input
+            v-model="updatePassWord.checkNewPassWord"
+            type="password"
+            :disabled="!isEditPassWord"
+          />
         </el-form-item>
-        <div class="flex">
+        <div class="flex items-center justify-end py-5" v-if="!isEditPassWord">
           <button
-            class="ms-auto rounded border border-secondary-900 px-14 py-2 font-bold text-secondary-900 md:py-3"
-            @click.prevent="handleChangePassword(ruleFormRef)"
+            class="rounded border border-secondary-900 px-14 py-2 font-bold text-secondary-900 md:py-3"
+            @click.prevent="handleEditPassWord(ruleFormRef)"
           >
             更改密碼
+          </button>
+        </div>
+        <div class="flex items-center justify-end gap-x-4 py-5" v-else>
+          <button
+            class="rounded border border-secondary-900 px-14 py-2 font-bold text-secondary-900 md:py-3"
+            @click.prevent="handleEditPassWord(ruleFormRef)"
+          >
+            取消
+          </button>
+          <button
+            class="rounded border border-secondary-900 px-14 py-2 font-bold text-secondary-900 md:py-3"
+            @click.prevent="handleChangePassword(ruleFormRef)"
+          >
+            確認
           </button>
         </div>
       </el-form>


### PR DESCRIPTION
會員中心更新
1.添加 可編輯/不可編輯 狀態
2.添加會員資訊 帳號需為必填 且 信箱格式
3.使用者使用 優化 - 未儲存點選取消時 ，無論是否輸入更改，皆會還原 預設值( 原本資料 )