### PR TITLE
refactor/multiple-pages

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -2,10 +2,12 @@
 import { computed, onMounted, onBeforeMount } from 'vue'
 import { useRoute } from 'vue-router'
 import { RouterView } from 'vue-router'
+import { useMemberStore } from '@/stores/member'
 import HeaderLayout from '@/components/global/HeaderLayout.vue'
 import FooterLayout from '@/components/global/FooterLayout.vue'
 import ThePlaidAdorn from './components/global/ThePlaidAdorn.vue'
 const route = useRoute()
+const memberStore = useMemberStore()
 
 // 判斷是否應該隱藏 footer
 const hiddenFooter = computed(() => {
@@ -17,6 +19,10 @@ onBeforeMount(() => {
   if (loadingElement) {
     loadingElement.remove()
   }
+})
+onMounted(async () => {
+  //由是否取得到會員資料來判斷 會員是否已經登入，來維持登入狀態( 由member.ts內的 isLoginStatus 控制 )
+  await memberStore.fetchMemberInfo()
 })
 </script>
 

--- a/src/components/global/HeaderLayout.vue
+++ b/src/components/global/HeaderLayout.vue
@@ -21,7 +21,7 @@ const memberStore = useMemberStore()
 const mainNav = computed(() => [
   { id: 'usage', title: '使用方式', path: '/how-to-use' },
   { id: 'plan', title: '方案選擇', path: '/plan-selection' },
-  { id: 'cart', title: '購物車', path: '/checkout' },
+  { id: 'cart', title: '購物車', path: '/checkout' }
 ])
 
 // ...(memberStore.getMemberInfo.id
@@ -52,7 +52,7 @@ watch(
               <TheSvg class="h-[40px]" svgIcon="logo" />
             </RouterLink>
           </h1>
-          <h1 class="block text-center pt-3 md:hidden">
+          <h1 class="block pt-3 text-center md:hidden">
             <RouterLink to="/">
               <TheSvg class="h-[40px] w-[100px]" svgIcon="mobile-logo" />
             </RouterLink>
@@ -63,22 +63,51 @@ watch(
         <div class="flex w-9/12 items-center justify-end gap-x-4">
           <!-- 手機板會隱藏此處 -->
           <ul class="hidden items-center gap-x-4 md:flex">
-            <li class="relative w-24 h-10">
+            <!-- <li class="relative h-10 w-24">
               <Transition name="fade" mode="out-in">
-                <RouterLink v-if="!memberStore.getMemberInfo.id" key="signin"
+                <RouterLink
+                  v-if="!memberStore.getLoginStatus"
+                  key="signin"
                   class="absolute inset-0 flex items-center justify-center p-2 font-bold text-[#7C7C7C] hover:text-primary-700"
-                  to="/signin">
+                  to="/signin"
+                >
                   登入 / 註冊
                 </RouterLink>
-                <RouterLink v-else key="user"
+                <RouterLink
+                  v-else
+                  key="user"
                   class="absolute inset-0 flex items-center justify-center p-2 font-bold text-[#7C7C7C] hover:text-primary-700"
-                  to="/member">
+                  to="/member"
+                >
+                  會員中心
+                </RouterLink>
+              </Transition>
+            </li> -->
+            <li class="h-10 w-24">
+              <Transition name="fade" mode="out-in">
+                <RouterLink
+                  v-if="!memberStore.getLoginStatus"
+                  key="signin"
+                  class="flex h-full w-full items-center justify-center p-2 font-bold text-[#7C7C7C] hover:text-primary-700"
+                  to="/signin"
+                >
+                  登入 / 註冊
+                </RouterLink>
+                <RouterLink
+                  v-else
+                  key="user"
+                  class="flex h-full w-full items-center justify-center p-2 font-bold text-[#7C7C7C] hover:text-primary-700"
+                  to="/member"
+                >
                   會員中心
                 </RouterLink>
               </Transition>
             </li>
             <li v-for="mainNavItem in mainNav" :key="mainNavItem.id">
-              <RouterLink class="block p-2 font-bold text-[#7C7C7C] hover:text-primary-700" :to="`${mainNavItem.path}`">
+              <RouterLink
+                class="block p-2 font-bold text-[#7C7C7C] hover:text-primary-700"
+                :to="`${mainNavItem.path}`"
+              >
                 {{ mainNavItem.title }}
               </RouterLink>
             </li>
@@ -92,33 +121,49 @@ watch(
             </li>
           </ul> -->
           <!-- 用來控制縮合的按鈕，手機板才會顯示 -->
-          <button class="hover:block cursor-pointer p-2 md:hidden" @click="toggleMenu">
+          <button class="cursor-pointer p-2 hover:block md:hidden" @click="toggleMenu">
             <RouterLink key="cart" class="font-bold hover:text-primary-700" to="/checkout">
               <font-awesome-icon :icon="['fas', 'cart-shopping']" size="xl" />
             </RouterLink>
           </button>
-          <button class="hover:block cursor-pointer p-2 md:hidden" @click="toggleMenu">
+          <button class="cursor-pointer p-2 hover:block md:hidden" @click="toggleMenu">
             <FontAwesomeIcon :icon="['fas', 'bars']" size="xl" />
           </button>
         </div>
       </div>
     </nav>
-    <transition enter-active-class="transition ease-out duration-200" enter-from-class="opacity-0 -translate-y-1"
-      enter-to-class="opacity-100 translate-y-0" leave-active-class="transition ease-in duration-150"
-      leave-from-class="opacity-100 translate-y-0" leave-to-class="opacity-0 -translate-y-1">
+    <transition
+      enter-active-class="transition ease-out duration-200"
+      enter-from-class="opacity-0 -translate-y-1"
+      enter-to-class="opacity-100 translate-y-0"
+      leave-active-class="transition ease-in duration-150"
+      leave-from-class="opacity-100 translate-y-0"
+      leave-to-class="opacity-0 -translate-y-1"
+    >
       <div v-show="isOpen" class="absolute left-0 right-0 z-10 w-full bg-white shadow-lg md:hidden">
         <ul class="py-2">
           <li>
-            <RouterLink v-if="!memberStore.getMemberInfo.id" key="signin" class="block p-4 hover:bg-primary-200"
-              to="/signin">
+            <RouterLink
+              v-if="!memberStore.getMemberInfo.id"
+              key="signin"
+              class="block p-4 hover:bg-primary-200"
+              to="/signin"
+            >
               登入 / 註冊
             </RouterLink>
             <RouterLink v-else key="user" class="block p-4 hover:bg-primary-200" to="/member">
               會員中心
             </RouterLink>
           </li>
-          <li v-for="mainNavItem in mainNav.filter(item => item.id !== 'cart')" :key="mainNavItem.id">
-            <RouterLink class="block p-4 hover:bg-primary-200" :to="mainNavItem.path" @click="isOpen = false">
+          <li
+            v-for="mainNavItem in mainNav.filter((item) => item.id !== 'cart')"
+            :key="mainNavItem.id"
+          >
+            <RouterLink
+              class="block p-4 hover:bg-primary-200"
+              :to="mainNavItem.path"
+              @click="isOpen = false"
+            >
               {{ mainNavItem.title }}
             </RouterLink>
           </li>
@@ -130,7 +175,9 @@ watch(
 <style scoped>
 .fade-enter-active,
 .fade-leave-active {
-  transition: opacity 0.3s ease, transform 0.3s ease;
+  transition:
+    opacity 0.3s ease,
+    transform 0.3s ease;
 }
 
 .fade-enter-from,

--- a/src/components/global/MealCard.vue
+++ b/src/components/global/MealCard.vue
@@ -1,4 +1,8 @@
 <script setup>
+import { Plus, Minus, Loading } from '@element-plus/icons-vue'
+import { computed, watch, inject } from 'vue'
+import { useCartStore } from '@/stores/cart'
+const cartStore = useCartStore()
 const props = defineProps({
   mealInfo: {
     type: Object,
@@ -16,6 +20,20 @@ const props = defineProps({
     default: () => {}
   }
 })
+const isGeneralAddButtonLoad = inject('isGeneralAddButtonLoad')
+const isGeneralDelButtonLoad = inject('isGeneralDelButtonLoad')
+const isGeneralMealId = inject('isGeneralMealId')
+const addButtonLoad = computed(() => {
+  return isGeneralMealId.value === props.mealInfo.id && isGeneralAddButtonLoad.value
+})
+const delButtonLoad = computed(() => {
+  return isGeneralMealId.value === props.mealInfo.id && isGeneralDelButtonLoad.value
+})
+const lockButton = computed(() => isGeneralAddButtonLoad.value || isGeneralDelButtonLoad.value)
+const cartMealQty = computed(() => {
+  const cartItem = cartStore.getGeneralBoxes.find((item) => item.id === props.mealInfo.id)
+  return cartItem ? cartItem.boxQuantity : 0
+})
 </script>
 <template>
   <li class="flex flex-col gap-y-4 rounded border p-4">
@@ -25,14 +43,62 @@ const props = defineProps({
       <RouterLink :to="`/singlemeal/${mealInfo.id}`">
         <p class="font-bold">{{ mealInfo.name }}</p>
       </RouterLink>
-      <ul class="flex flex-row flex-wrap items-center gap-x-4 gap-y-4 text-[10px] sm:text-[14px]">
+      <!-- <ul class="flex flex-row flex-wrap items-center gap-x-4 gap-y-4 text-[10px] sm:text-[14px]">
         <li class="text-center">{{ mealInfo.composition.calories }}Kcal</li>
         <li class="text-center">蛋白質{{ mealInfo.composition.protein }}g</li>
-        <li class="text-center">纖維{{ mealInfo.composition.fiber }}g</li>
-      </ul>
+        <li class="text-center">碳水{{ mealInfo.composition.carbohydrate }}g</li>
+      </ul> -->
+      <p class="text-[10px] sm:text-[14px]">
+        {{ mealInfo.composition.calories }}Kcal &ensp;|&ensp; 蛋白質{{
+          mealInfo.composition.protein
+        }}g &ensp;|&ensp; 碳水{{ mealInfo.composition.carbohydrate }}g
+      </p>
     </div>
-    <div class="mt-auto flex gap-x-3">
-      <button
+    <div class="mt-auto flex items-center gap-x-3">
+      <el-button
+        :disabled="lockButton"
+        @click="minusData(mealInfo.id)"
+        size="large"
+        type="default"
+        class="hidden w-1/2 flex-grow items-center justify-center gap-x-2 md:flex"
+      >
+        <template #default>
+          <div class="flex items-center gap-x-3">
+            <el-icon v-if="!delButtonLoad">
+              <Minus />
+            </el-icon>
+            <el-icon class="is-loading" v-else>
+              <Loading />
+            </el-icon>
+            <p>刪除</p>
+          </div>
+        </template>
+      </el-button>
+      <el-button
+        :disabled="lockButton"
+        size="large"
+        @click="addData(mealInfo.id)"
+        class="add-button flex w-1/2 flex-grow items-center justify-center gap-x-2"
+      >
+        <template #default>
+          <div class="flex items-center gap-x-3">
+            <el-icon v-if="!addButtonLoad">
+              <Plus />
+            </el-icon>
+
+            <el-icon class="is-loading" v-else>
+              <Loading />
+            </el-icon>
+            <p class="text-primary-700">加入</p>
+          </div>
+        </template>
+      </el-button>
+      <!-- <el-button
+        v-else
+        class="add-button flex h-full w-1/2 flex-grow items-center justify-center gap-x-2"
+        loading
+      ></el-button> -->
+      <!-- <button
         @click="minusData(mealInfo.id)"
         class="hidden flex-grow items-center justify-center gap-x-2 rounded border border-black py-2 md:flex"
       >
@@ -43,8 +109,23 @@ const props = defineProps({
         class="flex flex-grow items-center justify-center gap-x-2 rounded border border-primary-700 py-2 text-primary-700"
       >
         <FontAwesomeIcon :icon="['fas', 'plus']" class="text-primary-700" />加入
-      </button>
+      </button> -->
+      <div class="flex gap-x-1 self-end text-[12px] font-bold">
+        <p>
+          {{ cartMealQty }}
+        </p>
+        <p>餐</p>
+      </div>
     </div>
   </li>
 </template>
-<style lang="scss" scoped></style>
+<style lang="scss" scoped>
+:deep(.el-button) {
+  @apply mx-0 rounded border;
+}
+.add-button {
+  :deep(.el-icon) {
+    color: $primary-700;
+  }
+}
+</style>

--- a/src/components/register-page/RegisterForm.vue
+++ b/src/components/register-page/RegisterForm.vue
@@ -1,116 +1,123 @@
 <script lang="ts" setup>
 import { ref } from 'vue'
-import type { FormInstance } from 'element-plus'
-import { useRouter, type Router } from 'vue-router'
-import { useAuthStore } from '@/stores/auth'
-const authStore = useAuthStore()
+import type { FormRules,FormInstance } from 'element-plus'
+// import { useRouter, type Router } from 'vue-router'
+// import { useAuthStore } from '@/stores/auth'
+// const authStore = useAuthStore()
 const ruleFormRef = ref<FormInstance>()
-const isLoading = ref<Boolean>(false)
-const router: Router = useRouter()
-type RegisterInputType = {
-  account: string
-  password: string
-  checkPassWord: string
-  privacy: string[]
-  newSletter: string[]
-}
-const registerInput = ref<RegisterInputType>({
-  account: '',
-  password: '',
-  checkPassWord: '',
-  privacy: [],
-  newSletter: []
-})
-const validatePass = (rule: any, value: any, callback: any) => {
-  if (value === '') {
-    callback(new Error('請輸入密碼'))
-  } else {
-    if (registerInput.value.password !== '') {
-      if (!ruleFormRef.value) return
-      ruleFormRef.value.validateField('checkPassWord')
-    }
-    callback()
-  }
-}
-const validatePass2 = (rule: any, value: any, callback: any) => {
-  if (value === '') {
-    callback(new Error('請輸入密碼'))
-  } else if (value !== registerInput.value.password) {
-    callback(new Error('密碼與原先不符合'))
-  } else {
-    callback()
-  }
-}
+// const isLoading = ref<Boolean>(false)
+// const router: Router = useRouter()
+// type RegisterInputType = {
+//   account: string
+//   password: string
+//   checkPassWord: string
+//   privacy: string[]
+//   newSletter: string[]
+// }
+// const registerInput = ref<RegisterInputType>({
+//   account: '',
+//   password: '',
+//   checkPassWord: '',
+//   privacy: [],
+//   newSletter: []
+// })
+// const validatePass = (rule: any, value: any, callback: any) => {
+//   if (value === '') {
+//     callback(new Error('請輸入密碼'))
+//   } else {
+//     if (registerInput.value.password !== '') {
+//       if (!ruleFormRef.value) return
+//       ruleFormRef.value.validateField('checkPassWord')
+//     }
+//     callback()
+//   }
+// }
+// const validatePass2 = (rule: any, value: any, callback: any) => {
+//   if (value === '') {
+//     callback(new Error('請輸入密碼'))
+//   } else if (value !== registerInput.value.password) {
+//     callback(new Error('密碼與原先不符合'))
+//   } else {
+//     callback()
+//   }
+// }
 
-const registerRules = ref({
-  account: [
-    {
-      type: 'email',
-      required: true,
-      message: '信箱格式不相符',
-      trigger: ['blur', 'change']
-    }
-  ],
-  password: [
-    { min: 2, max: 30, message: '長度介於6到30之間', trigger: 'blur' },
-    { required: true, message: '必填', trigger: 'blur' },
-    { validator: validatePass, trigger: 'blur' }
-  ],
-  checkPassWord: [
-    { min: 6, max: 30, message: '長度介於6到30之間', trigger: 'blur' },
-    { required: true, message: '不能為空', trigger: 'blur' },
-    { validator: validatePass2, trigger: 'blur' }
-  ],
-  privacy: [
-    {
-      type: 'array',
-      required: true,
-      message: '請詳細閱讀隱私條款',
-      trigger: 'change'
-    }
-  ]
-})
-const handleRegister = async (formEl: FormInstance | undefined) => {
-  if (!formEl) return
-  await formEl.validate(async (valid, fields) => {
-    if (valid) {
-      await fetchRegister(registerInput.value)
-      // console.log('發送註冊API')
-    } else {
-      // console.log('error submit!', fields)
-    }
-  })
-}
-const message = (mes: any, mesType: any): void => {
-  //@ts-ignore
-  ElMessage({
-    message: mes,
-    type: mesType,
-    duration: 1500
-  })
-}
-const fetchRegister = async (data: RegisterInputType) => {
-  const { account, password } = data
-  const fetchData = { account, password }
-  try {
-    isLoading.value = true
-    const response: any = await authStore.register(fetchData)
-    message(response.message, 'success')
-    router.push('/signin')
-  } catch (error: any) {
-    message(error.message, 'error')
-  } finally {
-    isLoading.value = false
-  }
-}
+// const registerRules = ref({
+//   account: [
+//     {
+//       type: 'email',
+//       required: true,
+//       message: '信箱格式不相符',
+//       trigger: ['blur', 'change']
+//     }
+//   ],
+//   password: [
+//     { min: 2, max: 30, message: '長度介於6到30之間', trigger: 'blur' },
+//     { required: true, message: '必填', trigger: 'blur' },
+//     { validator: validatePass, trigger: 'blur' }
+//   ],
+//   checkPassWord: [
+//     { min: 6, max: 30, message: '長度介於6到30之間', trigger: 'blur' },
+//     { required: true, message: '不能為空', trigger: 'blur' },
+//     { validator: validatePass2, trigger: 'blur' }
+//   ],
+//   privacy: [
+//     {
+//       type: 'array',
+//       required: true,
+//       message: '請詳細閱讀隱私條款',
+//       trigger: 'change'
+//     }
+//   ]
+// })
+// const handleRegister = async (formEl: FormInstance | undefined) => {
+//   if (!formEl) return
+//   await formEl.validate(async (valid, fields) => {
+//     if (valid) {
+//       await fetchRegister(registerInput.value)
+//       // console.log('發送註冊API')
+//     } else {
+//       // console.log('error submit!', fields)
+//     }
+//   })
+// }
+// const message = (mes: any, mesType: any): void => {
+//   //@ts-ignore
+//   ElMessage({
+//     message: mes,
+//     type: mesType,
+//     duration: 1500
+//   })
+// }
+// const fetchRegister = async (data: RegisterInputType) => {
+//   const { account, password } = data
+//   const fetchData = { account, password }
+//   try {
+//     isLoading.value = true
+//     const response: any = await authStore.register(fetchData)
+//     message(response.message, 'success')
+//     router.push('/signin')
+//   } catch (error: any) {
+//     message(error.message, 'error')
+//   } finally {
+//     isLoading.value = false
+//   }
+// }
+const registerInput = defineModel('registerInput', { type: Object })
+const props = defineProps<{
+  rules: FormRules
+  loading: boolean
+  handleRegister: (formEl: FormInstance | undefined) => Promise<void>
+  // formRef: FormInstance | undefined
+}>()
 </script>
 <template>
   <el-form
     class="el-form-font-size"
     ref="ruleFormRef"
-    :rules="registerRules"
+    :rules="rules"
     :model="registerInput"
-    v-loading="isLoading"
+    v-loading="loading"
   >
     <el-form-item label="登入電子信箱帳號:" label-position="top" prop="account">
       <el-input v-model="registerInput.account" />

--- a/src/components/register-page/RegisterForm.vue
+++ b/src/components/register-page/RegisterForm.vue
@@ -1,115 +1,14 @@
 <script lang="ts" setup>
 import { ref } from 'vue'
 import type { FormRules, FormInstance } from 'element-plus'
-// import { useRouter, type Router } from 'vue-router'
-// import { useAuthStore } from '@/stores/auth'
-// const authStore = useAuthStore()
 const ruleFormRef = ref<FormInstance>()
-// const isLoading = ref<Boolean>(false)
-// const router: Router = useRouter()
-// type RegisterInputType = {
-//   account: string
-//   password: string
-//   checkPassWord: string
-//   privacy: string[]
-//   newSletter: string[]
-// }
-// const registerInput = ref<RegisterInputType>({
-//   account: '',
-//   password: '',
-//   checkPassWord: '',
-//   privacy: [],
-//   newSletter: []
-// })
-// const validatePass = (rule: any, value: any, callback: any) => {
-//   if (value === '') {
-//     callback(new Error('請輸入密碼'))
-//   } else {
-//     if (registerInput.value.password !== '') {
-//       if (!ruleFormRef.value) return
-//       ruleFormRef.value.validateField('checkPassWord')
-//     }
-//     callback()
-//   }
-// }
-// const validatePass2 = (rule: any, value: any, callback: any) => {
-//   if (value === '') {
-//     callback(new Error('請輸入密碼'))
-//   } else if (value !== registerInput.value.password) {
-//     callback(new Error('密碼與原先不符合'))
-//   } else {
-//     callback()
-//   }
-// }
-
-// const registerRules = ref({
-//   account: [
-//     {
-//       type: 'email',
-//       required: true,
-//       message: '信箱格式不相符',
-//       trigger: ['blur', 'change']
-//     }
-//   ],
-//   password: [
-//     { min: 2, max: 30, message: '長度介於6到30之間', trigger: 'blur' },
-//     { required: true, message: '必填', trigger: 'blur' },
-//     { validator: validatePass, trigger: 'blur' }
-//   ],
-//   checkPassWord: [
-//     { min: 6, max: 30, message: '長度介於6到30之間', trigger: 'blur' },
-//     { required: true, message: '不能為空', trigger: 'blur' },
-//     { validator: validatePass2, trigger: 'blur' }
-//   ],
-//   privacy: [
-//     {
-//       type: 'array',
-//       required: true,
-//       message: '請詳細閱讀隱私條款',
-//       trigger: 'change'
-//     }
-//   ]
-// })
-// const handleRegister = async (formEl: FormInstance | undefined) => {
-//   if (!formEl) return
-//   await formEl.validate(async (valid, fields) => {
-//     if (valid) {
-//       await fetchRegister(registerInput.value)
-//       // console.log('發送註冊API')
-//     } else {
-//       // console.log('error submit!', fields)
-//     }
-//   })
-// }
-// const message = (mes: any, mesType: any): void => {
-//   //@ts-ignore
-//   ElMessage({
-//     message: mes,
-//     type: mesType,
-//     duration: 1500
-//   })
-// }
-// const fetchRegister = async (data: RegisterInputType) => {
-//   const { account, password } = data
-//   const fetchData = { account, password }
-//   try {
-//     isLoading.value = true
-//     const response: any = await authStore.register(fetchData)
-//     message(response.message, 'success')
-//     router.push('/signin')
-//   } catch (error: any) {
-//     message(error.message, 'error')
-//   } finally {
-//     isLoading.value = false
-//   }
-// }
 const registerInput = defineModel('registerInput', { type: Object })
 defineProps<{
-  // rules: FormRules
   loading: boolean
   handleRegister: (formEl: FormInstance | undefined) => Promise<void>
-  // formRef: FormInstance | undefined
 }>()
+
+//驗證 密碼
 const validatePass = (rule: any, value: any, callback: any) => {
   if (value === '') {
     callback(new Error('請輸入密碼'))
@@ -121,6 +20,8 @@ const validatePass = (rule: any, value: any, callback: any) => {
     callback()
   }
 }
+
+//驗證 2次密碼
 const validatePass2 = (rule: any, value: any, callback: any) => {
   if (value === '') {
     callback(new Error('請輸入密碼'))
@@ -131,6 +32,7 @@ const validatePass2 = (rule: any, value: any, callback: any) => {
   }
 }
 
+//其餘驗證規則
 const registerRules = ref<FormRules>({
   account: [
     {
@@ -141,14 +43,14 @@ const registerRules = ref<FormRules>({
     }
   ],
   password: [
-    { min: 2, max: 30, message: '長度介於2到30之間', trigger: 'blur' },
-    { required: true, message: '必填', trigger: 'blur' },
-    { validator: validatePass, trigger: 'blur' }
+    { min: 2, max: 30, message: '長度介於2到30之間', trigger: ['blur', 'change'] },
+    { required: true, message: '必填', trigger: ['blur', 'change'] },
+    { validator: validatePass, trigger: ['blur', 'change'] }
   ],
   checkPassWord: [
-    { min: 2, max: 30, message: '長度介於2到30之間', trigger: 'blur' },
-    { required: true, message: '必填', trigger: 'blur' },
-    { validator: validatePass2, trigger: 'blur' }
+    { min: 2, max: 30, message: '長度介於2到30之間', trigger: ['blur', 'change'] },
+    { required: true, message: '必填', trigger: ['blur', 'change'] },
+    { validator: validatePass2, trigger: ['blur', 'change'] }
   ],
   privacy: [
     {

--- a/src/components/register-page/RegisterForm.vue
+++ b/src/components/register-page/RegisterForm.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
 import { ref } from 'vue'
-import type { FormRules,FormInstance } from 'element-plus'
+import type { FormRules, FormInstance } from 'element-plus'
 // import { useRouter, type Router } from 'vue-router'
 // import { useAuthStore } from '@/stores/auth'
 // const authStore = useAuthStore()
@@ -104,18 +104,67 @@ const ruleFormRef = ref<FormInstance>()
 //   }
 // }
 const registerInput = defineModel('registerInput', { type: Object })
-const props = defineProps<{
-  rules: FormRules
+defineProps<{
+  // rules: FormRules
   loading: boolean
   handleRegister: (formEl: FormInstance | undefined) => Promise<void>
   // formRef: FormInstance | undefined
 }>()
+const validatePass = (rule: any, value: any, callback: any) => {
+  if (value === '') {
+    callback(new Error('請輸入密碼'))
+  } else {
+    if (registerInput.value.password !== '') {
+      if (!ruleFormRef.value) return
+      ruleFormRef.value?.validateField('checkPassWord')
+    }
+    callback()
+  }
+}
+const validatePass2 = (rule: any, value: any, callback: any) => {
+  if (value === '') {
+    callback(new Error('請輸入密碼'))
+  } else if (value !== registerInput.value.password) {
+    callback(new Error('密碼與原先不符合'))
+  } else {
+    callback()
+  }
+}
+
+const registerRules = ref<FormRules>({
+  account: [
+    {
+      type: 'email',
+      required: true,
+      message: '信箱格式不相符',
+      trigger: ['blur', 'change']
+    }
+  ],
+  password: [
+    { min: 2, max: 30, message: '長度介於2到30之間', trigger: 'blur' },
+    { required: true, message: '必填', trigger: 'blur' },
+    { validator: validatePass, trigger: 'blur' }
+  ],
+  checkPassWord: [
+    { min: 2, max: 30, message: '長度介於2到30之間', trigger: 'blur' },
+    { required: true, message: '必填', trigger: 'blur' },
+    { validator: validatePass2, trigger: 'blur' }
+  ],
+  privacy: [
+    {
+      type: 'array',
+      required: true,
+      message: '請詳細閱讀隱私條款',
+      trigger: 'change'
+    }
+  ]
+})
 </script>
 <template>
   <el-form
     class="el-form-font-size"
     ref="ruleFormRef"
-    :rules="rules"
+    :rules="registerRules"
     :model="registerInput"
     v-loading="loading"
   >

--- a/src/components/signin-page/SigninForm.vue
+++ b/src/components/signin-page/SigninForm.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
 import { ref } from 'vue'
-import type { FormRules,FormInstance } from 'element-plus'
+import type { FormRules, FormInstance } from 'element-plus'
 // import { useRouter, type Router } from 'vue-router'
 // import { useAuthStore } from '@/stores/auth'
 // const authStore = useAuthStore()
@@ -61,18 +61,32 @@ const ruleFormRef = ref<FormInstance>()
 //   }
 // }
 const signinInput = defineModel('signinInput', { type: Object })
-const props = defineProps<{
-  rules: FormRules
+defineProps<{
+  // rules: FormRules
   loading: boolean
   handleSignin: (formEl: FormInstance | undefined) => Promise<void>
   // formRef: FormInstance | undefined
 }>()
+const signinRules = ref<FormRules>({
+  account: [
+    {
+      type: 'email',
+      required: true,
+      message: '信箱格式不相符',
+      trigger: ['blur', 'change']
+    }
+  ],
+  password: [
+    { min: 2, max: 30, message: '長度介於2到30之間', trigger: ['blur', 'change'] },
+    { required: true, message: '必填', trigger: ['blur', 'change'] }
+  ]
+})
 </script>
 <template>
   <el-form
     class="el-form-font-size"
     ref="ruleFormRef"
-    :rules="rules"
+    :rules="signinRules"
     :model="signinInput"
     v-loading="loading"
   >

--- a/src/components/signin-page/SigninForm.vue
+++ b/src/components/signin-page/SigninForm.vue
@@ -1,73 +1,80 @@
 <script lang="ts" setup>
 import { ref } from 'vue'
-import type { FormInstance } from 'element-plus'
-import { useRouter, type Router } from 'vue-router'
-import { useAuthStore } from '@/stores/auth'
-const authStore = useAuthStore()
+import type { FormRules,FormInstance } from 'element-plus'
+// import { useRouter, type Router } from 'vue-router'
+// import { useAuthStore } from '@/stores/auth'
+// const authStore = useAuthStore()
 const ruleFormRef = ref<FormInstance>()
-const isLoading = ref<Boolean>(false)
-type SigninInputType = {
-  account: string
-  password: string
-}
-const router: Router = useRouter()
-const signinInput = ref<SigninInputType>({
-  account: '',
-  password: ''
-})
-const registerRules = ref({
-  account: [
-    {
-      type: 'email',
-      required: true,
-      message: '信箱格式不相符',
-      trigger: ['blur', 'change']
-    }
-  ],
-  password: [
-    { min: 2, max: 30, message: '長度介於6到30之間', trigger: 'blur' },
-    { required: true, message: '必填', trigger: 'blur' }
-  ]
-})
-const handleRegister = async (formEl: FormInstance | undefined) => {
-  if (!formEl) return
-  await formEl.validate(async (valid, fields) => {
-    if (valid) {
-      await fetchSignin(signinInput.value)
-      // console.log('發送登入API')
-    } else {
-      // console.log('error submit!', fields)
-    }
-  })
-}
-const message = (mes: any, mesType: any): void => {
-  //@ts-ignore
-  ElMessage({
-    message: mes,
-    type: mesType,
-    duration: 1500
-  })
-}
-const fetchSignin = async (data: SigninInputType) => {
-  try {
-    isLoading.value = true
-    const response: any = await authStore.signin(data)
-    message(response.message, 'success')
-    router.push('/')
-  } catch (error: any) {
-    message(error.message, 'error')
-  } finally {
-    isLoading.value = false
-  }
-}
+// const isLoading = ref<boolean>(false)
+// type SigninInputType = {
+//   account: string
+//   password: string
+// }
+// const router: Router = useRouter()
+// const signinInput = ref<SigninInputType>({
+//   account: '',
+//   password: ''
+// })
+// const registerRules = ref({
+//   account: [
+//     {
+//       type: 'email',
+//       required: true,
+//       message: '信箱格式不相符',
+//       trigger: ['blur', 'change']
+//     }
+//   ],
+//   password: [
+//     { min: 2, max: 30, message: '長度介於6到30之間', trigger: 'blur' },
+//     { required: true, message: '必填', trigger: 'blur' }
+//   ]
+// })
+// const handleRegister = async (formEl: FormInstance | undefined) => {
+//   if (!formEl) return
+//   await formEl.validate(async (valid, fields) => {
+//     if (valid) {
+//       await fetchSignin(signinInput.value)
+//       // console.log('發送登入API')
+//     } else {
+//       // console.log('error submit!', fields)
+//     }
+//   })
+// }
+// const message = (mes: any, mesType: any): void => {
+//   //@ts-ignore
+//   ElMessage({
+//     message: mes,
+//     type: mesType,
+//     duration: 1500
+//   })
+// }
+// const fetchSignin = async (data: SigninInputType) => {
+//   try {
+//     isLoading.value = true
+//     const response: any = await authStore.signin(data)
+//     message(response.message, 'success')
+//     router.push('/')
+//   } catch (error: any) {
+//     message(error.message, 'error')
+//   } finally {
+//     isLoading.value = false
+//   }
+// }
+const signinInput = defineModel('signinInput', { type: Object })
+const props = defineProps<{
+  rules: FormRules
+  loading: boolean
+  handleSignin: (formEl: FormInstance | undefined) => Promise<void>
+  // formRef: FormInstance | undefined
+}>()
 </script>
 <template>
   <el-form
     class="el-form-font-size"
     ref="ruleFormRef"
-    :rules="registerRules"
+    :rules="rules"
     :model="signinInput"
-    v-loading="isLoading"
+    v-loading="loading"
   >
     <el-form-item label="登入電子信箱帳號:" label-position="top" prop="account">
       <el-input v-model="signinInput.account" />
@@ -80,7 +87,7 @@ const fetchSignin = async (data: SigninInputType) => {
     </div>
     <button
       class="w-full rounded-md bg-primary-300 px-4 py-3 text-center font-bold"
-      @click.prevent="handleRegister(ruleFormRef)"
+      @click.prevent="handleSignin(ruleFormRef)"
     >
       登入
     </button>

--- a/src/components/signin-page/SigninForm.vue
+++ b/src/components/signin-page/SigninForm.vue
@@ -1,72 +1,14 @@
 <script lang="ts" setup>
 import { ref } from 'vue'
 import type { FormRules, FormInstance } from 'element-plus'
-// import { useRouter, type Router } from 'vue-router'
-// import { useAuthStore } from '@/stores/auth'
-// const authStore = useAuthStore()
 const ruleFormRef = ref<FormInstance>()
-// const isLoading = ref<boolean>(false)
-// type SigninInputType = {
-//   account: string
-//   password: string
-// }
-// const router: Router = useRouter()
-// const signinInput = ref<SigninInputType>({
-//   account: '',
-//   password: ''
-// })
-// const registerRules = ref({
-//   account: [
-//     {
-//       type: 'email',
-//       required: true,
-//       message: '信箱格式不相符',
-//       trigger: ['blur', 'change']
-//     }
-//   ],
-//   password: [
-//     { min: 2, max: 30, message: '長度介於6到30之間', trigger: 'blur' },
-//     { required: true, message: '必填', trigger: 'blur' }
-//   ]
-// })
-// const handleRegister = async (formEl: FormInstance | undefined) => {
-//   if (!formEl) return
-//   await formEl.validate(async (valid, fields) => {
-//     if (valid) {
-//       await fetchSignin(signinInput.value)
-//       // console.log('發送登入API')
-//     } else {
-//       // console.log('error submit!', fields)
-//     }
-//   })
-// }
-// const message = (mes: any, mesType: any): void => {
-//   //@ts-ignore
-//   ElMessage({
-//     message: mes,
-//     type: mesType,
-//     duration: 1500
-//   })
-// }
-// const fetchSignin = async (data: SigninInputType) => {
-//   try {
-//     isLoading.value = true
-//     const response: any = await authStore.signin(data)
-//     message(response.message, 'success')
-//     router.push('/')
-//   } catch (error: any) {
-//     message(error.message, 'error')
-//   } finally {
-//     isLoading.value = false
-//   }
-// }
 const signinInput = defineModel('signinInput', { type: Object })
 defineProps<{
-  // rules: FormRules
   loading: boolean
   handleSignin: (formEl: FormInstance | undefined) => Promise<void>
-  // formRef: FormInstance | undefined
 }>()
+
+//登入 驗證規則
 const signinRules = ref<FormRules>({
   account: [
     {

--- a/src/stores/member.ts
+++ b/src/stores/member.ts
@@ -16,6 +16,9 @@ export const useMemberStore = defineStore('member', () => {
   const customCurrentPage = ref(1) // 自定義當前分頁
   const customPageSize = ref(10) //自定義每頁該顯示的資料數量
 
+  //會員登入狀態
+  const isLoginStatus = ref(false)
+
   /* Getter */
   const getMemberInfo = computed(() => {
     return {
@@ -84,6 +87,9 @@ export const useMemberStore = defineStore('member', () => {
     return customMealBoxStore.getCustomMeal.slice(start, end)
   })
 
+  //取得會員登入狀態
+  const getLoginStatus = computed(() => isLoginStatus.value)
+
   /* Action */
 
   //取得會員資料
@@ -92,9 +98,11 @@ export const useMemberStore = defineStore('member', () => {
       const response = await fetchApi.getUserInfo()
       if (response.status === 200) {
         memberInfo.value = response.data.data
+        isLoginStatus.value = true
         // console.log(memberInfo.value)
       }
     } catch (error: any) {
+      isLoginStatus.value = false
       throw error.response.data
     }
   }
@@ -177,6 +185,7 @@ export const useMemberStore = defineStore('member', () => {
     getCustomPageSize,
     getCustomPages,
     getPaginatedCustom,
+    getLoginStatus,
     fetchMemberInfo,
     fetchMemberOrder,
     updateMemberInfo,

--- a/src/types/type.ts
+++ b/src/types/type.ts
@@ -266,3 +266,18 @@ export type customMealBox = {
   imgSrc: string;
   createTime: string;
 };
+
+//註冊資料 型別
+export type RegisterInputType = {
+  account: string
+  password: string
+  checkPassWord: string
+  privacy: string[]
+  newSletter: string[]
+}
+
+//登入資料 型別
+export type SigninInputType = {
+  account: string
+  password: string
+}

--- a/src/views/MealboxlistPage.vue
+++ b/src/views/MealboxlistPage.vue
@@ -14,6 +14,9 @@ const cartStore = useCartStore()
 const drawer = ref(false)
 const isCardLoaning = ref(false)
 const isExpanded = ref(false) //控制預覽列以及遮罩
+const isGeneralAddButtonLoad = ref(false) //一般餐盒 是否點擊添加按鈕 狀態
+const isGeneralDelButtonLoad = ref(false) //一般餐盒 是否點擊刪除按鈕 狀態
+const isGeneralMealId = ref(-1) //一般餐盒 選中餐盒的id
 const getDirection = computed(() => (width.value >= 768 ? 'rtl' : 'btt'))
 const getDirectionHeight = computed(() => (width.value >= 768 ? '60%' : '50%'))
 const message = (mes: any, mesType: any): void => {
@@ -21,7 +24,8 @@ const message = (mes: any, mesType: any): void => {
   ElMessage({
     message: mes,
     type: mesType,
-    duration: 1500
+    duration: 750,
+    grouping: true
   })
 }
 const addGeneralCart = async (id: number) => {
@@ -102,8 +106,26 @@ onMounted(async () => {
   changeIsCardLoaning()
 })
 
+//一般餐盒 點擊按鈕 修改 是否點擊添加按鈕 狀態
+const handleGeneralAddButton = () => {
+  isGeneralAddButtonLoad.value = !isGeneralAddButtonLoad.value
+}
+//一般餐盒 點擊按鈕 修改 是否點擊刪除按鈕 狀態
+const handleGeneralDelButton = () => {
+  isGeneralDelButtonLoad.value = !isGeneralDelButtonLoad.value
+}
+//一般餐盒 點擊按鈕 修改 選中餐盒id
+const handleGeneralMealId = (id: any) => {
+  isGeneralMealId.value = id
+}
 provide('isCardLoaning', readonly(isCardLoaning))
 provide('changeIsCardLoaning', changeIsCardLoaning)
+provide('isGeneralAddButtonLoad', readonly(isGeneralAddButtonLoad))
+provide('isGeneralDelButtonLoad', readonly(isGeneralDelButtonLoad))
+provide('isGeneralMealId', readonly(isGeneralMealId))
+provide('handleGeneralAddButton', handleGeneralAddButton)
+provide('handleGeneralDelButton', handleGeneralDelButton)
+provide('handleGeneralMealId', handleGeneralMealId)
 </script>
 <template>
   <main class="flex flex-grow flex-col pb-40">

--- a/src/views/RegisterPage.vue
+++ b/src/views/RegisterPage.vue
@@ -2,7 +2,8 @@
 import { ref } from 'vue'
 import { useRouter, type Router } from 'vue-router'
 import { useAuthStore } from '@/stores/auth'
-import type { FormInstance, FormRules } from 'element-plus'
+import type { RegisterInputType } from '@/types/type'
+import type { FormInstance } from 'element-plus'
 import RegisterForm from '@/components/register-page/RegisterForm.vue'
 import AuthNavigation from '@/components/global/AuthNavigation.vue'
 import ExternalAuthButton from '@/components/global/ExternalAuthButton.vue'
@@ -10,14 +11,6 @@ import TheSvg from '@/components/global/TheSvg.vue'
 const authStore = useAuthStore()
 const isLoading = ref<boolean>(false)
 const router: Router = useRouter()
-// const ruleFormRef = ref<FormInstance>()
-type RegisterInputType = {
-  account: string
-  password: string
-  checkPassWord: string
-  privacy: string[]
-  newSletter: string[]
-}
 const registerInput = ref<RegisterInputType>({
   account: '',
   password: '',
@@ -45,55 +38,14 @@ const authButtonData = [
     }
   }
 ]
-// const validatePass = (rule: any, value: any, callback: any) => {
-//   if (value === '') {
-//     callback(new Error('請輸入密碼'))
-//   } else {
-//     if (registerInput.value.password !== '') {
-//       if (!ruleFormRef.value) return
-//       ruleFormRef.value?.validateField('checkPassWord')
-//     }
-//     callback()
-//   }
-// }
-// const validatePass2 = (rule: any, value: any, callback: any) => {
-//   if (value === '') {
-//     callback(new Error('請輸入密碼'))
-//   } else if (value !== registerInput.value.password) {
-//     callback(new Error('密碼與原先不符合'))
-//   } else {
-//     callback()
-//   }
-// }
-
-// const registerRules = ref<FormRules>({
-//   account: [
-//     {
-//       type: 'email',
-//       required: true,
-//       message: '信箱格式不相符',
-//       trigger: ['blur', 'change']
-//     }
-//   ],
-//   password: [
-//     { min: 2, max: 30, message: '長度介於2到30之間', trigger: 'blur' },
-//     { required: true, message: '必填', trigger: 'blur' },
-//     { validator: validatePass, trigger: 'blur' }
-//   ],
-//   checkPassWord: [
-//     { min: 6, max: 30, message: '長度介於2到30之間', trigger: 'blur' },
-//     { required: true, message: '必填', trigger: 'blur' },
-//     { validator: validatePass2, trigger: 'blur' }
-//   ],
-//   privacy: [
-//     {
-//       type: 'array',
-//       required: true,
-//       message: '請詳細閱讀隱私條款',
-//       trigger: 'change'
-//     }
-//   ]
-// })
+const message = (mes: any, mesType: any): void => {
+  //@ts-ignore
+  ElMessage({
+    message: mes,
+    type: mesType,
+    duration: 1500
+  })
+}
 const handleRegister = async (formEl: FormInstance | undefined) => {
   // ruleFormRef.value = formEl
   if (!formEl) return
@@ -106,14 +58,7 @@ const handleRegister = async (formEl: FormInstance | undefined) => {
     }
   })
 }
-const message = (mes: any, mesType: any): void => {
-  //@ts-ignore
-  ElMessage({
-    message: mes,
-    type: mesType,
-    duration: 1500
-  })
-}
+
 const fetchRegister = async (data: RegisterInputType) => {
   const { account, password } = data
   const fetchData = { account, password }

--- a/src/views/RegisterPage.vue
+++ b/src/views/RegisterPage.vue
@@ -10,7 +10,7 @@ import TheSvg from '@/components/global/TheSvg.vue'
 const authStore = useAuthStore()
 const isLoading = ref<boolean>(false)
 const router: Router = useRouter()
-const ruleFormRef = ref<FormInstance>()
+// const ruleFormRef = ref<FormInstance>()
 type RegisterInputType = {
   account: string
   password: string
@@ -45,57 +45,57 @@ const authButtonData = [
     }
   }
 ]
-const validatePass = (rule: any, value: any, callback: any) => {
-  if (value === '') {
-    callback(new Error('請輸入密碼'))
-  } else {
-    if (registerInput.value.password !== '') {
-      if (!ruleFormRef.value) return
-      ruleFormRef.value.validateField('checkPassWord')
-    }
-    callback()
-  }
-}
-const validatePass2 = (rule: any, value: any, callback: any) => {
-  if (value === '') {
-    callback(new Error('請輸入密碼'))
-  } else if (value !== registerInput.value.password) {
-    callback(new Error('密碼與原先不符合'))
-  } else {
-    callback()
-  }
-}
+// const validatePass = (rule: any, value: any, callback: any) => {
+//   if (value === '') {
+//     callback(new Error('請輸入密碼'))
+//   } else {
+//     if (registerInput.value.password !== '') {
+//       if (!ruleFormRef.value) return
+//       ruleFormRef.value?.validateField('checkPassWord')
+//     }
+//     callback()
+//   }
+// }
+// const validatePass2 = (rule: any, value: any, callback: any) => {
+//   if (value === '') {
+//     callback(new Error('請輸入密碼'))
+//   } else if (value !== registerInput.value.password) {
+//     callback(new Error('密碼與原先不符合'))
+//   } else {
+//     callback()
+//   }
+// }
 
-const registerRules = ref<FormRules>({
-  account: [
-    {
-      type: 'email',
-      required: true,
-      message: '信箱格式不相符',
-      trigger: ['blur', 'change']
-    }
-  ],
-  password: [
-    { min: 2, max: 30, message: '長度介於2到30之間', trigger: 'blur' },
-    { required: true, message: '必填', trigger: 'blur' },
-    { validator: validatePass, trigger: 'blur' }
-  ],
-  checkPassWord: [
-    { min: 6, max: 30, message: '長度介於2到30之間', trigger: 'blur' },
-    { required: true, message: '必填', trigger: 'blur' },
-    { validator: validatePass2, trigger: 'blur' }
-  ],
-  privacy: [
-    {
-      type: 'array',
-      required: true,
-      message: '請詳細閱讀隱私條款',
-      trigger: 'change'
-    }
-  ]
-})
+// const registerRules = ref<FormRules>({
+//   account: [
+//     {
+//       type: 'email',
+//       required: true,
+//       message: '信箱格式不相符',
+//       trigger: ['blur', 'change']
+//     }
+//   ],
+//   password: [
+//     { min: 2, max: 30, message: '長度介於2到30之間', trigger: 'blur' },
+//     { required: true, message: '必填', trigger: 'blur' },
+//     { validator: validatePass, trigger: 'blur' }
+//   ],
+//   checkPassWord: [
+//     { min: 6, max: 30, message: '長度介於2到30之間', trigger: 'blur' },
+//     { required: true, message: '必填', trigger: 'blur' },
+//     { validator: validatePass2, trigger: 'blur' }
+//   ],
+//   privacy: [
+//     {
+//       type: 'array',
+//       required: true,
+//       message: '請詳細閱讀隱私條款',
+//       trigger: 'change'
+//     }
+//   ]
+// })
 const handleRegister = async (formEl: FormInstance | undefined) => {
-  ruleFormRef.value = formEl
+  // ruleFormRef.value = formEl
   if (!formEl) return
   await formEl.validate(async (valid, fields) => {
     if (valid) {
@@ -137,10 +137,8 @@ const fetchRegister = async (data: RegisterInputType) => {
         <!-- <RegisterForm /> -->
         <RegisterForm
           v-model:registerInput="registerInput"
-          :rules="registerRules"
           :loading="isLoading"
           :handleRegister="handleRegister"
-          ref="ruleFormRef"
         />
         <el-divider><p style="color: #9cb0c9">OR</p></el-divider>
         <ExternalAuthButton

--- a/src/views/RegisterPage.vue
+++ b/src/views/RegisterPage.vue
@@ -1,8 +1,30 @@
 <script lang="ts" setup>
+import { ref } from 'vue'
+import { useRouter, type Router } from 'vue-router'
+import { useAuthStore } from '@/stores/auth'
+import type { FormInstance, FormRules } from 'element-plus'
 import RegisterForm from '@/components/register-page/RegisterForm.vue'
 import AuthNavigation from '@/components/global/AuthNavigation.vue'
 import ExternalAuthButton from '@/components/global/ExternalAuthButton.vue'
 import TheSvg from '@/components/global/TheSvg.vue'
+const authStore = useAuthStore()
+const isLoading = ref<boolean>(false)
+const router: Router = useRouter()
+const ruleFormRef = ref<FormInstance>()
+type RegisterInputType = {
+  account: string
+  password: string
+  checkPassWord: string
+  privacy: string[]
+  newSletter: string[]
+}
+const registerInput = ref<RegisterInputType>({
+  account: '',
+  password: '',
+  checkPassWord: '',
+  privacy: [],
+  newSletter: []
+})
 const authButtonData = [
   {
     buttonClass: 'border border-[#1161B4] text-[#1161B4]',
@@ -23,13 +45,103 @@ const authButtonData = [
     }
   }
 ]
+const validatePass = (rule: any, value: any, callback: any) => {
+  if (value === '') {
+    callback(new Error('請輸入密碼'))
+  } else {
+    if (registerInput.value.password !== '') {
+      if (!ruleFormRef.value) return
+      ruleFormRef.value.validateField('checkPassWord')
+    }
+    callback()
+  }
+}
+const validatePass2 = (rule: any, value: any, callback: any) => {
+  if (value === '') {
+    callback(new Error('請輸入密碼'))
+  } else if (value !== registerInput.value.password) {
+    callback(new Error('密碼與原先不符合'))
+  } else {
+    callback()
+  }
+}
+
+const registerRules = ref<FormRules>({
+  account: [
+    {
+      type: 'email',
+      required: true,
+      message: '信箱格式不相符',
+      trigger: ['blur', 'change']
+    }
+  ],
+  password: [
+    { min: 2, max: 30, message: '長度介於2到30之間', trigger: 'blur' },
+    { required: true, message: '必填', trigger: 'blur' },
+    { validator: validatePass, trigger: 'blur' }
+  ],
+  checkPassWord: [
+    { min: 6, max: 30, message: '長度介於2到30之間', trigger: 'blur' },
+    { required: true, message: '必填', trigger: 'blur' },
+    { validator: validatePass2, trigger: 'blur' }
+  ],
+  privacy: [
+    {
+      type: 'array',
+      required: true,
+      message: '請詳細閱讀隱私條款',
+      trigger: 'change'
+    }
+  ]
+})
+const handleRegister = async (formEl: FormInstance | undefined) => {
+  ruleFormRef.value = formEl
+  if (!formEl) return
+  await formEl.validate(async (valid, fields) => {
+    if (valid) {
+      await fetchRegister(registerInput.value)
+      // console.log('發送註冊API')
+    } else {
+      // console.log('error submit!', fields)
+    }
+  })
+}
+const message = (mes: any, mesType: any): void => {
+  //@ts-ignore
+  ElMessage({
+    message: mes,
+    type: mesType,
+    duration: 1500
+  })
+}
+const fetchRegister = async (data: RegisterInputType) => {
+  const { account, password } = data
+  const fetchData = { account, password }
+  try {
+    isLoading.value = true
+    const response: any = await authStore.register(fetchData)
+    message(response.message, 'success')
+    router.push('/signin')
+  } catch (error: any) {
+    message(error.message, 'error')
+  } finally {
+    isLoading.value = false
+  }
+}
 </script>
 <template>
   <main class="container flex flex-col">
     <div class="grid grid-cols-12 gap-6 py-20">
       <div class="col-span-12 md:col-start-4 md:col-end-10">
         <AuthNavigation class="mb-12" />
-        <RegisterForm />
+        <!-- <RegisterForm /> -->
+        <RegisterForm
+          v-model:registerInput="registerInput"
+          :rules="registerRules"
+          :loading="isLoading"
+          :handleRegister="handleRegister"
+          ref="ruleFormRef"
+        />
         <el-divider><p style="color: #9cb0c9">OR</p></el-divider>
         <ExternalAuthButton
           v-for="buttonOption in authButtonData"

--- a/src/views/SigninPage.vue
+++ b/src/views/SigninPage.vue
@@ -1,8 +1,20 @@
 <script lang="ts" setup>
+import { ref } from 'vue'
+import { useRouter, type Router } from 'vue-router'
+import { useAuthStore } from '@/stores/auth'
+import type { SigninInputType } from '@/types/type'
+import type { FormRules, FormInstance } from 'element-plus'
 import SigninForm from '@/components/signin-page/SigninForm.vue'
 import AuthNavigation from '@/components/global/AuthNavigation.vue'
 import ExternalAuthButton from '@/components/global/ExternalAuthButton.vue'
 import TheSvg from '@/components/global/TheSvg.vue'
+const authStore = useAuthStore()
+const isLoading = ref<boolean>(false)
+const router: Router = useRouter()
+const signinInput = ref<SigninInputType>({
+  account: '',
+  password: ''
+})
 const authButtonData = [
   {
     buttonClass: 'border border-[#1161B4] text-[#1161B4]',
@@ -23,36 +35,14 @@ const authButtonData = [
     }
   }
 ]
-import { ref } from 'vue'
-import type { FormRules, FormInstance } from 'element-plus'
-import { useRouter, type Router } from 'vue-router'
-import { useAuthStore } from '@/stores/auth'
-const authStore = useAuthStore()
-const ruleFormRef = ref<FormInstance>()
-const isLoading = ref<boolean>(false)
-type SigninInputType = {
-  account: string
-  password: string
+const message = (mes: any, mesType: any): void => {
+  //@ts-ignore
+  ElMessage({
+    message: mes,
+    type: mesType,
+    duration: 1500
+  })
 }
-const router: Router = useRouter()
-const signinInput = ref<SigninInputType>({
-  account: '',
-  password: ''
-})
-const signinRules = ref<FormRules>({
-  account: [
-    {
-      type: 'email',
-      required: true,
-      message: '信箱格式不相符',
-      trigger: ['blur', 'change']
-    }
-  ],
-  password: [
-    { min: 2, max: 30, message: '長度介於2到30之間', trigger: ['blur', 'change'] },
-    { required: true, message: '必填', trigger: ['blur', 'change'] }
-  ]
-})
 const handleSignin = async (formEl: FormInstance | undefined) => {
   if (!formEl) return
   await formEl.validate(async (valid, fields) => {
@@ -62,14 +52,6 @@ const handleSignin = async (formEl: FormInstance | undefined) => {
     } else {
       // console.log('error submit!', fields)
     }
-  })
-}
-const message = (mes: any, mesType: any): void => {
-  //@ts-ignore
-  ElMessage({
-    message: mes,
-    type: mesType,
-    duration: 1500
   })
 }
 const fetchSignin = async (data: SigninInputType) => {

--- a/src/views/SigninPage.vue
+++ b/src/views/SigninPage.vue
@@ -23,13 +23,82 @@ const authButtonData = [
     }
   }
 ]
+import { ref } from 'vue'
+import type { FormRules, FormInstance } from 'element-plus'
+import { useRouter, type Router } from 'vue-router'
+import { useAuthStore } from '@/stores/auth'
+const authStore = useAuthStore()
+const ruleFormRef = ref<FormInstance>()
+const isLoading = ref<boolean>(false)
+type SigninInputType = {
+  account: string
+  password: string
+}
+const router: Router = useRouter()
+const signinInput = ref<SigninInputType>({
+  account: '',
+  password: ''
+})
+const signinRules = ref<FormRules>({
+  account: [
+    {
+      type: 'email',
+      required: true,
+      message: '信箱格式不相符',
+      trigger: ['blur', 'change']
+    }
+  ],
+  password: [
+    { min: 2, max: 30, message: '長度介於2到30之間', trigger: ['blur', 'change'] },
+    { required: true, message: '必填', trigger: ['blur', 'change'] }
+  ]
+})
+const handleSignin = async (formEl: FormInstance | undefined) => {
+  ruleFormRef.value = formEl
+  if (!formEl) return
+  await formEl.validate(async (valid, fields) => {
+    if (valid) {
+      await fetchSignin(signinInput.value)
+      // console.log('發送登入API')
+    } else {
+      // console.log('error submit!', fields)
+    }
+  })
+}
+const message = (mes: any, mesType: any): void => {
+  //@ts-ignore
+  ElMessage({
+    message: mes,
+    type: mesType,
+    duration: 1500
+  })
+}
+const fetchSignin = async (data: SigninInputType) => {
+  try {
+    isLoading.value = true
+    const response: any = await authStore.signin(data)
+    message(response.message, 'success')
+    router.push('/')
+  } catch (error: any) {
+    message(error.message, 'error')
+  } finally {
+    isLoading.value = false
+  }
+}
 </script>
 <template>
   <main class="container flex flex-col">
     <div class="grid grid-cols-12 gap-6 py-20">
       <div class="col-span-12 md:col-start-4 md:col-end-10">
         <AuthNavigation class="mb-12" />
-        <SigninForm />
+        <!-- <SigninForm /> -->
+        <SigninForm
+          v-model:signinInput="signinInput"
+          :rules="signinRules"
+          :loading="isLoading"
+          :handleSignin="handleSignin"
+          ref="ruleFormRef"
+        />
         <el-divider><p style="color: #9cb0c9">OR</p></el-divider>
         <ExternalAuthButton
           v-for="buttonOption in authButtonData"

--- a/src/views/SigninPage.vue
+++ b/src/views/SigninPage.vue
@@ -54,7 +54,6 @@ const signinRules = ref<FormRules>({
   ]
 })
 const handleSignin = async (formEl: FormInstance | undefined) => {
-  ruleFormRef.value = formEl
   if (!formEl) return
   await formEl.validate(async (valid, fields) => {
     if (valid) {
@@ -94,10 +93,8 @@ const fetchSignin = async (data: SigninInputType) => {
         <!-- <SigninForm /> -->
         <SigninForm
           v-model:signinInput="signinInput"
-          :rules="signinRules"
           :loading="isLoading"
           :handleSignin="handleSignin"
-          ref="ruleFormRef"
         />
         <el-divider><p style="color: #9cb0c9">OR</p></el-divider>
         <ExternalAuthButton

--- a/src/views/mealbox-list-page/MealGeneralPage.vue
+++ b/src/views/mealbox-list-page/MealGeneralPage.vue
@@ -9,6 +9,9 @@ const generalMealBoxStore = useGeneralMealBoxStore()
 const cartStore = useCartStore()
 const isCardLoaning = inject('isCardLoaning')
 const changeIsCardLoaning = inject('changeIsCardLoaning')
+const handleGeneralMealId = inject('handleGeneralMealId')
+const handleGeneralAddButton = inject('handleGeneralAddButton')
+const handleGeneralDelButton = inject('handleGeneralDelButton')
 const nutrientsValue = ref('all')
 const nutrientsOptions = [
   {
@@ -27,14 +30,14 @@ const nutrientsOptions = [
   //   value: 'adipose',
   //   label: '依 脂肪排序'
   // },
-  // {
-  //   value: 'carbohydrate',
-  //   label: '依 碳水化合物排序'
-  // },
   {
-    value: 'fiber',
-    label: '依 纖維排序'
+    value: 'carbohydrate',
+    label: '依 碳水化合物排序'
   }
+  // {
+  //   value: 'fiber',
+  //   label: '依 纖維排序'
+  // }
   // {
   //   value: 'sodium',
   //   label: '依 鈉含量排序'
@@ -45,11 +48,14 @@ const message = (mes, mesType) => {
   ElMessage({
     message: mes,
     type: mesType,
-    duration: 1500
+    duration: 750,
+    grouping: true
   })
 }
 const addGeneralCart = async (id) => {
   try {
+    handleGeneralMealId(id)
+    handleGeneralAddButton()
     const response = await cartStore.fetchaddGeneralCart(id)
     if (response === 'endOrder') {
       return
@@ -58,10 +64,15 @@ const addGeneralCart = async (id) => {
     }
   } catch (error) {
     message(error.message, 'error')
+  } finally {
+    handleGeneralMealId(-1)
+    handleGeneralAddButton()
   }
 }
 const minusGeneralCart = async (id) => {
   try {
+    handleGeneralMealId(id)
+    handleGeneralDelButton()
     const response = await cartStore.fetchMinusGeneralCart(id)
     if (response === 'notExist') {
       return
@@ -70,6 +81,9 @@ const minusGeneralCart = async (id) => {
     }
   } catch (error) {
     message(error.message, 'error')
+  } finally {
+    handleGeneralMealId(-1)
+    handleGeneralDelButton()
   }
 }
 


### PR DESCRIPTION
1.重構 登入註冊 邏輯內容，將input資料以及發送api方式移到父組件 ，子組件只留下驗證規則  以及顯示內容。

2.更新 header 的 登入/註冊 變成 會員中心。
-登入完成後， 登入/註冊 變成 會員中心，但是當使用者在其他頁面重整，會導致會員中心 再度變回  登入/註冊。
-在member 添加一個已登入的狀態(isLoginStatus)，透過此狀態 判斷   登入/註冊 或是 會員中心。
-透過 App.vue中去 發送取得會員資料 來判斷  isLoginStatus 目前狀態。

3.更新 一般餐盒一些功能畫面
-添加刪除、 加入按鈕 的非同步讀取狀態，點擊加入或刪除，會鎖住所有按鈕呈現disabled狀態，點擊的按鈕會有loading效果，當請求結束返回各初始狀態。
-在商品卡右下角，添加以購入餐盒數量，方便使用者知道需不需要各別刪除。